### PR TITLE
Add enrol command to readme instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ open an issue on this repo and let me know!
 ```
 # this command enrols the currently attached Yubikey as an identity that can
 # assume two IAM roles.
+$ cloudkey enrol
     --identity unique-name-for-this-identity \
     --role role-name-that-can-be-assumed \
     --role maybe-a-second-role-name-too


### PR DESCRIPTION
I am not actually sure that this is the correct command but this is what I was able
to guess based off `main.go` and running `cloudkey help`